### PR TITLE
Fix extra component rendering in BlogPosts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kalynbeach-com",
   "author": "Kalyn Beach",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "private": true,
   "scripts": {
@@ -16,9 +16,9 @@
     "@astrojs/mdx": "^0.19.1",
     "@astrojs/partytown": "^1.2.1",
     "@astrojs/rss": "^2.4.1",
-    "@astrojs/sitemap": "^1.3.0",
+    "@astrojs/sitemap": "^1.3.1",
     "@astrojs/tailwind": "^3.1.2",
-    "astro": "^2.4.3",
+    "astro": "^2.4.4",
     "sharp": "^0.32.1",
     "tailwindcss": "^3.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kalynbeach-com",
   "author": "Kalyn Beach",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "private": true,
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,10 +3,10 @@ lockfileVersion: '6.0'
 dependencies:
   '@astrojs/image':
     specifier: ^0.16.7
-    version: 0.16.7(astro@2.4.3)(sharp@0.32.1)
+    version: 0.16.7(astro@2.4.4)(sharp@0.32.1)
   '@astrojs/mdx':
     specifier: ^0.19.1
-    version: 0.19.1(astro@2.4.3)(rollup@3.21.0)
+    version: 0.19.1(astro@2.4.4)(rollup@3.21.0)
   '@astrojs/partytown':
     specifier: ^1.2.1
     version: 1.2.1
@@ -14,14 +14,14 @@ dependencies:
     specifier: ^2.4.1
     version: 2.4.1
   '@astrojs/sitemap':
-    specifier: ^1.3.0
-    version: 1.3.0
+    specifier: ^1.3.1
+    version: 1.3.1
   '@astrojs/tailwind':
     specifier: ^3.1.2
-    version: 3.1.2(astro@2.4.3)(tailwindcss@3.3.2)
+    version: 3.1.2(astro@2.4.4)(tailwindcss@3.3.2)
   astro:
-    specifier: ^2.4.3
-    version: 2.4.3(sharp@0.32.1)
+    specifier: ^2.4.4
+    version: 2.4.4(sharp@0.32.1)
   sharp:
     specifier: ^0.32.1
     version: 0.32.1
@@ -52,7 +52,7 @@ packages:
     resolution: {integrity: sha512-aXAxapNWZwGN41P+Am/ma/2kAzKOhMNaY6YuvLkUHFv+UZkmDHD6F0fE1sQA2Up0bLjgPQa1VQzoAaii5tZWaA==}
     dev: false
 
-  /@astrojs/image@0.16.7(astro@2.4.3)(sharp@0.32.1):
+  /@astrojs/image@0.16.7(astro@2.4.4)(sharp@0.32.1):
     resolution: {integrity: sha512-8X1DnMh3lUTA7BNt7dF0rfWTXNwvLoPWWXtLi+TdO3CW1SvdY9LJRuCEWwHfnKzcQ0EC2TfLwjukpbtJuCRxjw==}
     peerDependencies:
       astro: ^2.3.4
@@ -62,7 +62,7 @@ packages:
         optional: true
     dependencies:
       '@altano/tiny-async-pool': 1.0.2
-      astro: 2.4.3(sharp@0.32.1)
+      astro: 2.4.4(sharp@0.32.1)
       http-cache-semantics: 4.1.1
       image-size: 1.0.2
       kleur: 4.1.5
@@ -90,13 +90,13 @@ packages:
       vscode-uri: 3.0.7
     dev: false
 
-  /@astrojs/markdown-remark@2.2.0(astro@2.4.3):
+  /@astrojs/markdown-remark@2.2.0(astro@2.4.4):
     resolution: {integrity: sha512-4M1+GzQwDqF0KfX9Ahug43b0avorcK+iTapEaVuNnaCUVS6sZKRkztT3g6hmXiFmGHSL8qYaS9IVEmKtP6hYmw==}
     peerDependencies:
       astro: ^2.4.0
     dependencies:
       '@astrojs/prism': 2.1.1
-      astro: 2.4.3(sharp@0.32.1)
+      astro: 2.4.4(sharp@0.32.1)
       github-slugger: 1.5.0
       import-meta-resolve: 2.2.2
       rehype-raw: 6.1.1
@@ -113,11 +113,11 @@ packages:
       - supports-color
     dev: false
 
-  /@astrojs/mdx@0.19.1(astro@2.4.3)(rollup@3.21.0):
+  /@astrojs/mdx@0.19.1(astro@2.4.4)(rollup@3.21.0):
     resolution: {integrity: sha512-9GNNZbGT+lGvbRkQK/NaEJcnjj1T94/ne0KwPjJgNCBQrJuskX5IW1hKiE5bRSOFvkAOrBGneYKg0GXYArBOQQ==}
     engines: {node: '>=16.12.0'}
     dependencies:
-      '@astrojs/markdown-remark': 2.2.0(astro@2.4.3)
+      '@astrojs/markdown-remark': 2.2.0(astro@2.4.4)
       '@astrojs/prism': 2.1.1
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/rollup': 2.3.0(rollup@3.21.0)
@@ -162,21 +162,21 @@ packages:
       kleur: 4.1.5
     dev: false
 
-  /@astrojs/sitemap@1.3.0:
-    resolution: {integrity: sha512-s1/v9MfnxVLvH5v4edK02bBAOMp5tuEvhPT1pJ2qaqXM6QZuqatk/xQU3kuWebQh+yqnD2yBeeHbmfwr4gG1vw==}
+  /@astrojs/sitemap@1.3.1:
+    resolution: {integrity: sha512-4ZBug4ml+2Nl5/Uh4VSja8Kij/DU7/RaNMciXCNm1EzQkP/jm+nqMG1liDDcQK5zXPAoLeaat06IbhNlruvQjg==}
     dependencies:
       sitemap: 7.1.1
       zod: 3.21.4
     dev: false
 
-  /@astrojs/tailwind@3.1.2(astro@2.4.3)(tailwindcss@3.3.2):
+  /@astrojs/tailwind@3.1.2(astro@2.4.4)(tailwindcss@3.3.2):
     resolution: {integrity: sha512-KyZ84WExLRU/TRIQm09ce+ND/0UG9AK9+7k/gjCbxuKScc/RieZ73oh4MkoEFrN/9OToMklvt+wmkAt3+u/ubQ==}
     peerDependencies:
       astro: ^2.3.3
       tailwindcss: ^3.0.24
     dependencies:
       '@proload/core': 0.3.3
-      astro: 2.4.3(sharp@0.32.1)
+      astro: 2.4.4(sharp@0.32.1)
       autoprefixer: 10.4.14(postcss@8.4.23)
       postcss: 8.4.23
       postcss-load-config: 4.0.1(postcss@8.4.23)
@@ -993,8 +993,8 @@ packages:
     hasBin: true
     dev: false
 
-  /astro@2.4.3(sharp@0.32.1):
-    resolution: {integrity: sha512-WU7sMkgFNQs4WZzEmpjOYZthcT8+LSmwIR0GvWzVYlb+dIMfFCQyg99LNHdhg/XZKi08ztaHmRf4ZBjJvZHsgA==}
+  /astro@2.4.4(sharp@0.32.1):
+    resolution: {integrity: sha512-2DFxcnZySS/OzBbiuWpoVGJBikcHfbwO5xmk5ohItswoMs+PfZ5P/B6mXplTjaosjm3M43c0OIsd8Mq6UksQZQ==}
     engines: {node: '>=16.12.0', npm: '>=6.14.0'}
     hasBin: true
     peerDependencies:
@@ -1005,7 +1005,7 @@ packages:
     dependencies:
       '@astrojs/compiler': 1.4.1
       '@astrojs/language-server': 1.0.4
-      '@astrojs/markdown-remark': 2.2.0(astro@2.4.3)
+      '@astrojs/markdown-remark': 2.2.0(astro@2.4.4)
       '@astrojs/telemetry': 2.1.1
       '@astrojs/webapi': 2.1.1
       '@babel/core': 7.21.4
@@ -1041,7 +1041,7 @@ packages:
       preferred-pm: 3.0.3
       prompts: 2.4.2
       rehype: 12.0.1
-      semver: 7.4.0
+      semver: 7.5.0
       server-destroy: 1.0.1
       sharp: 0.32.1
       shiki: 0.14.2
@@ -3398,14 +3398,6 @@ packages:
   /semver@6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
-    dev: false
-
-  /semver@7.4.0:
-    resolution: {integrity: sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
     dev: false
 
   /semver@7.5.0:

--- a/src/content/blog/markdown-style-guide.md
+++ b/src/content/blog/markdown-style-guide.md
@@ -3,7 +3,7 @@ title: "Markdown Style Guide"
 description: "Here is a sample of some basic Markdown syntax that can be used when writing Markdown content in Astro."
 pubDate: "Jul 01 2022"
 heroImage: "/placeholder-hero.jpg"
-draft: false
+draft: true
 ---
 
 Here is a sample of some basic Markdown syntax that can be used when writing Markdown content in Astro.

--- a/src/content/blog/markdown-style-guide.md
+++ b/src/content/blog/markdown-style-guide.md
@@ -1,10 +1,9 @@
 ---
-layout: "../../layouts/BlogPost.astro"
 title: "Markdown Style Guide"
 description: "Here is a sample of some basic Markdown syntax that can be used when writing Markdown content in Astro."
 pubDate: "Jul 01 2022"
 heroImage: "/placeholder-hero.jpg"
-draft: true
+draft: false
 ---
 
 Here is a sample of some basic Markdown syntax that can be used when writing Markdown content in Astro.

--- a/src/content/blog/using-mdx.mdx
+++ b/src/content/blog/using-mdx.mdx
@@ -1,10 +1,9 @@
 ---
-layout: '../../layouts/BlogPost.astro'
 title: 'Using MDX'
 description: 'Lorem ipsum dolor sit amet'
 pubDate: 'Jul 02 2022'
 heroImage: '/placeholder-hero.jpg'
-draft: true
+draft: false
 ---
 
 This theme comes with the [@astrojs/mdx](https://docs.astro.build/en/guides/integrations-guide/mdx/) integration installed and configured in your `astro.config.mjs` config file. If you prefer not to use MDX, you can disable support by removing the integration from your config file.

--- a/src/content/blog/using-mdx.mdx
+++ b/src/content/blog/using-mdx.mdx
@@ -3,7 +3,7 @@ title: 'Using MDX'
 description: 'Lorem ipsum dolor sit amet'
 pubDate: 'Jul 02 2022'
 heroImage: '/placeholder-hero.jpg'
-draft: false
+draft: true
 ---
 
 This theme comes with the [@astrojs/mdx](https://docs.astro.build/en/guides/integrations-guide/mdx/) integration installed and configured in your `astro.config.mjs` config file. If you prefer not to use MDX, you can disable support by removing the integration from your config file.

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -20,15 +20,15 @@ const pageTitle = `${title} | ${SITE_TITLE}`;
         class='w-full mb-6'
       />
     )}
-    <div class='mb-6 flex flex-col md:flex-row justify-between md:items-start font-mono'>
+    <div class='mb-6 flex flex-col md:flex-row justify-between items-center font-mono'>
       <h1 class='mb-4 md:mb-0 text-3xl'>
         {title}
       </h1>
-      {pubDate && <time class='mr-auto md:mr-0 md:ml-auto text-sm md:text-base text-neutral-400'>{pubDate}</time>}
+      {pubDate && <time class='mr-auto md:mr-0 md:ml-auto text-sm text-neutral-400'>{pubDate.toDateString()}</time>}
       {updatedDate && (
-        <div class='mt-1 md:mt-0 mr-auto md:mr-0 md:ml-3 text-sm md:text-base text-neutral-400'>
+        <div class='mt-1 md:mt-0 mr-auto md:mr-0 md:ml-3 text-sm text-neutral-400'>
           <span class='hidden md:inline-block'>&#45;</span> 
-          <span>Updated <time>{updatedDate}</time></span>
+          <span>Updated <time>{updatedDate.toDateString()}</time></span>
         </div>
       )}
     </div>
@@ -39,7 +39,23 @@ const pageTitle = `${title} | ${SITE_TITLE}`;
 </BaseLayout>
 
 <style>
-  article :global(p) {
+  section.post-content :global(h1) {
+    font-size: 1.85rem;
+    line-height: 2.25rem;
+    margin: 2rem 0 1.5rem;
+  }
+
+  section.post-content :global(h2) {
+    font-size: 1.5rem;
+    line-height: 2rem;
+    margin: 1.5rem 0 1rem;
+  }
+
+  section.post-content :global(p) {
     margin-bottom: 1rem;
+  }
+
+  section.post-content :global(pre) {
+    padding: 1rem;
   }
 </style>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -17,6 +17,5 @@ const { Content } = await post.render();
 ---
 
 <BlogPost {...post.data}>
-	<h1>{post.data.title}</h1>
 	<Content />
 </BlogPost>


### PR DESCRIPTION
This branch fixes the issue of `Header` and `Footer` components rendering within `BlogPost` pages and adds minor style updates.

The key here is to remove the `layout` value in blog content frontmatter. Blog content layout (`BlogPost`) rendering is done in `src/pages/blog/[...slug].astro` instead.

